### PR TITLE
Fix enum radio labels not handling click

### DIFF
--- a/src/sugoi/form/elements/Enum.hx
+++ b/src/sugoi/form/elements/Enum.hx
@@ -96,9 +96,9 @@ class Enum extends FormElement<Int>
 
 				var t = Form.translator;
 				if (t == null){
-					label = "<label for=\"" + n + c + "\" >" + Std.string(row)  +"</label>\n";
+					label = "<label for=\"" + n + row + "\" >" + Std.string(row)  +"</label>\n";
 				}else{
-					label = "<label for=\"" + n + c + "\" >" + t._(Std.string(row))  +"</label>\n";	
+					label = "<label for=\"" + n + row + "\" >" + t._(Std.string(row))  +"</label>\n";	
 				}
 				
 


### PR DESCRIPTION
Permet de cliquer sur un label pour sélectionner le choix (plutôt que de devoir viser précisément le bouton radio).
Côté accessibilité: corrige l'association entre le label et le radio button.